### PR TITLE
Add option to skip posts with ads/trials;

### DIFF
--- a/OF DL/Entities/Auth.cs
+++ b/OF DL/Entities/Auth.cs
@@ -27,6 +27,7 @@ namespace OF_DL.Entities
         public bool DownloadVideos { get; set; }
         public bool DownloadAudios { get; set; }
         public bool IncludeExpiredSubscriptions { get; set; }
+        public bool SkipAds { get; set; } = false;
         public string? DownloadPath { get; set; } = string.Empty;
 
     }

--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -723,7 +723,7 @@ namespace OF_DL.Helpers
                         }
 
                         DBHelper dBHelper = new DBHelper();
-                        foreach (Post.List post in posts.list)
+                        foreach (Post.List post in posts.list.Where(p => auth.SkipAds == false || (!p.rawText.Contains("#ad") && !p.rawText.Contains("/trial/"))))
                         {
                             List<long> postPreviewIds = new List<long>();
                             if (post.preview != null && post.preview.Count > 0)
@@ -1093,7 +1093,7 @@ namespace OF_DL.Helpers
                         }
 
                         DBHelper dBHelper = new DBHelper();
-                        foreach (Messages.List list in messages.list)
+                        foreach (Messages.List list in messages.list.Where(p => auth.SkipAds == false || (!p.text.Contains("#ad") && !p.text.Contains("/trial/"))))
                         {
                             List<long> messagePreviewIds = new List<long>();
                             if (list.previews != null && list.previews.Count > 0)


### PR DESCRIPTION
Particularly useful for free accounts where some creators post a lot of other user's content as an ad. These posts are usually time-limited, but if you download all of the posts from that user, you pick up the ad content.

I had a bit of trouble working out where to most effectively add this, but this seemed like the most effective spot. Likewise, I've tries to test it as much as I can, but I couldn't reproduce exactly the build you use for releases, so I've just tested what I could.