### PR TITLE
Use rawText and Prevent Errors

### DIFF
--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -712,7 +712,7 @@ public class APIHelper : IAPIHelper
                             }
                         }
                     }
-                    await m_DBHelper.AddPost(folder, post.id, post.text != null ? post.text : string.Empty, post.price != null ? post.price.ToString() : "0", post.price != null && post.isOpened ? true : false, post.isArchived, post.postedAt);
+                    await m_DBHelper.AddPost(folder, post.id, post.rawText != null ? post.rawText : string.Empty, post.price != null ? post.price.ToString() : "0", post.price != null && post.isOpened ? true : false, post.isArchived, post.postedAt);
                     if (post.media != null && post.media.Count > 0)
                     {
                         foreach (Post.Medium medium in post.media)
@@ -1483,7 +1483,7 @@ public class APIHelper : IAPIHelper
                         }
                     }
                 }
-                await m_DBHelper.AddPost(folder, post.id, post.text != null ? post.text : string.Empty, post.price != null ? post.price.ToString() : "0", post.price != null && post.isOpened ? true : false, post.isArchived, post.postedAt);
+                await m_DBHelper.AddPost(folder, post.id, post.rawText != null ? post.rawText : string.Empty, post.price != null ? post.price.ToString() : "0", post.price != null && post.isOpened ? true : false, post.isArchived, post.postedAt);
                 postCollection.PostObjects.Add(post);
                 if (post.media != null && post.media.Count > 0)
                 {

--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -169,7 +169,7 @@ public class DownloadHelper : IDownloadHelper
         properties.AddRange(matches.Select(match => match.Groups[1].Value));
 
         Dictionary<string, string> values = await fileNameHelper.GetFilename(postInfo, postMedia, author, properties, users);
-        return WidevineClient.Utils.RemoveInvalidFileNameChars(await fileNameHelper.BuildFilename(filenameFormat, values));
+        return await fileNameHelper.BuildFilename(filenameFormat, values);
     }
 
 

--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -169,7 +169,7 @@ public class DownloadHelper : IDownloadHelper
         properties.AddRange(matches.Select(match => match.Groups[1].Value));
 
         Dictionary<string, string> values = await fileNameHelper.GetFilename(postInfo, postMedia, author, properties, users);
-        return await fileNameHelper.BuildFilename(filenameFormat, values);
+        return WidevineClient.Utils.RemoveInvalidFileNameChars(await fileNameHelper.BuildFilename(filenameFormat, values));
     }
 
 

--- a/OF DL/Helpers/FileNameHelper.cs
+++ b/OF DL/Helpers/FileNameHelper.cs
@@ -120,6 +120,21 @@ namespace OF_DL.Helpers
                         values.Add(propertyName, users.FirstOrDefault(u => u.Value == Convert.ToInt32(nestedPropertyValue.ToString())).Key);
                     }
                 }
+                else if (propertyName.Contains("text", StringComparison.OrdinalIgnoreCase))
+                {
+                    PropertyInfo property = Array.Find(properties1, p => p.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase));
+                    if (property != null)
+                    {
+                        object propertyValue = property.GetValue(obj1);
+                        if (propertyValue != null)
+                        {
+                            var str = propertyValue.ToString();
+                            if (str.Length > 100) // todo: add length limit to config
+                                str = str.Substring(0, 100);
+                            values.Add(propertyName, str);
+                        }
+                    }
+                }
                 else
                 {
                     PropertyInfo property = Array.Find(properties1, p => p.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase));
@@ -162,7 +177,7 @@ namespace OF_DL.Helpers
                 fileFormat = fileFormat.Replace(placeholder, kvp.Value);
             }
 
-            return $"{fileFormat}";
+            return WidevineClient.Utils.RemoveInvalidFileNameChars($"{fileFormat}");
         }
     }
 }

--- a/OF DL/Utils.cs
+++ b/OF DL/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics;
@@ -150,6 +150,11 @@ namespace WidevineClient
         public static string Version()
         {
             return System.Reflection.Assembly.GetCallingAssembly().GetName().Version.ToString();
+        }
+
+        public static string? RemoveInvalidFileNameChars(string? fileName)
+        {
+            return string.IsNullOrEmpty(fileName) ? fileName : string.Concat(fileName.Split(Path.GetInvalidFileNameChars()));
         }
     }
 }


### PR DESCRIPTION
Add post rawText to the database instead of text. Filter out invalid file name characters to prevent filename errors. These changes allow the {rawText} tag to be used for PostFileNameFormat and PaidPostFileNameFormat. {text} tag can be used for the others (as well as the previously mentioned ones) though html content may be present in the output.