### PR TITLE
feat: add support to download posts incrementally

### DIFF
--- a/OF DL/Entities/Config.cs
+++ b/OF DL/Entities/Config.cs
@@ -51,6 +51,8 @@ namespace OF_DL.Entities
         public DateTime? CustomDate { get; set; } = null;
 
         public bool ShowScrapeSize { get; set; } = true;
+
+        public bool DownloadPostsIncrementally { get; set; } = false;
     }
 
 }

--- a/OF DL/Helpers/Interfaces/IDBHelper.cs
+++ b/OF DL/Helpers/Interfaces/IDBHelper.cs
@@ -12,5 +12,6 @@ namespace OF_DL.Helpers
         Task CheckUsername(KeyValuePair<string, int> user, string path);
         Task<long> GetStoredFileSize(string folder, long media_id);
         Task UpdateMedia(string folder, long media_id, string directory, string filename, long size, bool downloaded, DateTime created_at);
+        Task<DateTime?> GetMostRecentPostDate(string folder);
     }
 }


### PR DESCRIPTION
Just a quick implementation of a "incremental post download" to speed up creator downloads to see if there's any bites for it.
The idea is to avoid excessive calls to the API just to get Posts data for items that have already been downloaded, since we don't care. 

It checks the SQLite DB for the latest post downloaded or the first post that hasn't downloaded, and uses that DateTime to to query the API for available posts from.

If the CustomDate functionality is enabled, then incremental downloads are disabled. This functionality is most also be enabled in the config file.