### PR TITLE
Add docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+
+# Copy source code
 COPY ["OF DL.sln", "/src/OF DL.sln"]
 COPY ["OF DL", "/src/OF DL"]
+
 WORKDIR "/src"
+
+# Build release
 RUN dotnet publish -c Release -o out
 
+
 FROM mcr.microsoft.com/dotnet/runtime:7.0
+
+# Install dependencies
 RUN apt update -y && apt install -y ffmpeg
+
+# Copy release and entrypoint script
 COPY --from=build /src/out /app
 ADD docker/entrypoint.sh /app
 RUN chmod +x /app/entrypoint.sh
-RUN mkdir /data
-RUN mkdir /config
+
+RUN mkdir /data  # For downloaded files
+RUN mkdir /config  # For configuration files
+
 WORKDIR /config
 CMD /app/entrypoint.sh
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ WORKDIR "/src"
 RUN dotnet publish -c Release -o out
 
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0
+FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy
 
 # Install dependencies
-RUN apt update -y && apt install -y ffmpeg
+RUN apt-get update
+RUN apt-get install -y software-properties-common
+RUN add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
+RUN apt-get update
+RUN apt-get install -y ffmpeg
 
 # Copy release and entrypoint script
 COPY --from=build /src/out /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+COPY ["OF DL.sln", "/src/OF DL.sln"]
+COPY ["OF DL", "/src/OF DL"]
+WORKDIR "/src"
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/runtime:7.0
+RUN apt update -y && apt install -y ffmpeg
+COPY --from=build /src/out /app
+ADD docker/entrypoint.sh /app
+RUN chmod +x /app/entrypoint.sh
+RUN mkdir /data
+RUN mkdir /config
+WORKDIR /config
+CMD /app/entrypoint.sh
+

--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -38,7 +38,7 @@ public class DownloadHelper : IDownloadHelper
 
     #region common
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <param name="path"></param>
     /// <param name="url"></param>
@@ -392,7 +392,7 @@ public class DownloadHelper : IDownloadHelper
             if (fullPathWithTheServerFileName != fullPathWithTheNewFileName)
             {
                 finalPath = fullPathWithTheNewFileName;
-                //rename. 
+                //rename.
                 try
                 {
                     File.Move(fullPathWithTheServerFileName, fullPathWithTheNewFileName);
@@ -421,7 +421,7 @@ public class DownloadHelper : IDownloadHelper
         }
         // Handle the case where the file has been downloaded in the past with a custom filename.
         //but it has downloaded outsite of this application so it doesn't exist in the database
-        // this is a bit improbable but we should check for that. 
+        // this is a bit improbable but we should check for that.
         else if (File.Exists(fullPathWithTheNewFileName))
         {
             fileSizeInBytes = GetLocalFileSize(fullPathWithTheNewFileName);
@@ -436,7 +436,7 @@ public class DownloadHelper : IDownloadHelper
             }
             status = false;
         }
-        else //file doesn't exist and we should download it. 
+        else //file doesn't exist and we should download it.
         {
             lastModified = await DownloadFile(url, fullPathWithTheNewFileName, task, config, showScrapeSize);
             fileSizeInBytes = GetLocalFileSize(fullPathWithTheNewFileName);
@@ -444,7 +444,7 @@ public class DownloadHelper : IDownloadHelper
         }
 
         //finaly check which filename we should use. Custom or the server one.
-        //if a custom is used, then the servefilename will be different from the resolved filename. 
+        //if a custom is used, then the servefilename will be different from the resolved filename.
         string finalName = serverFilename == resolvedFilename ? serverFilename : resolvedFilename;
         await m_DBHelper.UpdateMedia(folder, media_id, folder + path, finalName + extension, fileSizeInBytes, true, lastModified);
         return status;
@@ -594,7 +594,10 @@ public class DownloadHelper : IDownloadHelper
         {
             FileName = ffmpegpath,
             Arguments = $"-cenc_decryption_key {decKey} -headers \"Cookie:CloudFront-Policy={policy}; CloudFront-Signature={signature}; CloudFront-Key-Pair-Id={kvp}; {sess}\r\nOrigin: https://onlyfans.com\r\nReferer: https://onlyfans.com\r\nUser-Agent: {user_agent}\r\n\r\n\" -i \"{url}\" -codec copy \"{tempFilename}\"",
-            CreateNoWindow = true
+            CreateNoWindow = true,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
         };
 
         Process ffmpegProcess = new()
@@ -863,7 +866,7 @@ public class DownloadHelper : IDownloadHelper
                     }
                     File.SetLastWriteTime(destinationPath, response.Content.Headers.LastModified?.LocalDateTime ?? DateTime.Now);
                 }
-                
+
             }
         }
         catch (Exception ex)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+mkdir -p /config/cdm/devices/chrome_1610
+
+if [ ! -f /config/auth.json ]; then
+	cat > /config/auth.json <<- EOF
+		{
+		  "USER_ID": "",
+		  "USER_AGENT": "",
+		  "X_BC": "",
+		  "COOKIE": "",
+		  "FFMPEG_PATH": "/usr/bin/ffmpeg"
+		}
+	EOF
+fi
+
+if [ ! -f /config/config.json ]; then
+	cat > /config/config.json <<- EOF
+		{
+		  "DownloadAvatarHeaderPhoto": true,
+		  "DownloadPaidPosts": true,
+		  "DownloadPosts": true,
+		  "DownloadArchived": true,
+		  "DownloadStreams": true,
+		  "DownloadStories": true,
+		  "DownloadHighlights": true,
+		  "DownloadMessages": true,
+		  "DownloadPaidMessages": true,
+		  "DownloadImages": true,
+		  "DownloadVideos": true,
+		  "DownloadAudios": true,
+		  "IncludeExpiredSubscriptions": true,
+		  "SkipAds": false,
+		  "DownloadPath": "/data/",
+		  "PaidPostFileNameFormat": "",
+		  "PostFileNameFormat": "",
+		  "PaidMessageFileNameFormat": "",
+		  "MessageFileNameFormat": "",
+		  "RenameExistingFilesWhenCustomFormatIsSelected": true,
+		  "Timeout": null,
+		  "FolderPerPaidPost": false,
+		  "FolderPerPost": false,
+		  "FolderPerPaidMessage": false,
+		  "FolderPerMessage": false,
+		  "LimitDownloadRate": false,
+		  "DownloadLimitInMbPerSec": 4,
+		  "DownloadOnlySpecificDates": false,
+		  "DownloadDateSelection": "after",
+		  "CustomDate": "",
+		  "ShowScrapeSize": false,
+		  "DownloadPostsIncrementally": false
+		}
+	EOF
+fi
+
+/app/OF\ DL
+


### PR DESCRIPTION
This PR contains a Dockerfile and entrypoint script to allow users to run OF-DL in a docker container. This will allow users to run OF-DL on operating systems other than Windows without having to setup a .NET development environment.

To build an OF-DL docker image, simply execute:
`docker build -t of-dl .` in the root of the repository

To run OF-DL in a docker container, then execute:
`docker run -it -v /{path to data directory}/:/data /{path to config directory}/:/config of-dl`

`{path to data directory}` should be replaced with the path to the folder on your computer where the downloaded data should be saved. `{path to config directory}` should be replaced with the path to the folder on your computer where you want to store the config for OF-DL. If `auth.json` and `config.json` don't exist in the config directory, files with default values will be created when you run the docker container.

While it is not included in this PR, you can add a simple GitHub action to automatically publish new docker images when you create new releases.