### PR TITLE
Add non-interactive mode

### DIFF
--- a/OF DL/Entities/Config.cs
+++ b/OF DL/Entities/Config.cs
@@ -53,6 +53,7 @@ namespace OF_DL.Entities
         public bool ShowScrapeSize { get; set; } = true;
 
         public bool DownloadPostsIncrementally { get; set; } = false;
+        public bool NonInteractiveMode { get; set; } = false;
         public string? FFmpegPath { get; set; } = string.Empty;
     }
 

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -211,7 +211,10 @@ public class Program
             await m_DBHelper.CreateUsersDB(users);
             Dictionary<string, int> lists = await m_ApiHelper.GetLists("/lists", Auth);
             Dictionary<string, int> selectedUsers = new();
-            KeyValuePair<bool, Dictionary<string, int>> hasSelectedUsersKVP = await HandleUserSelection(selectedUsers, users, lists);
+            KeyValuePair<bool, Dictionary<string, int>> hasSelectedUsersKVP =
+                Config.NonInteractiveMode
+                    ? new KeyValuePair<bool, Dictionary<string, int>>(true, users)
+                    : await HandleUserSelection(selectedUsers, users, lists);
 
             if (hasSelectedUsersKVP.Key && hasSelectedUsersKVP.Value != null && hasSelectedUsersKVP.Value.ContainsKey("SinglePost"))
             {
@@ -369,7 +372,7 @@ public class Program
             {
                 break;
             }
-        } while (true);
+        } while (!Config.NonInteractiveMode);
     }
 
     private static async Task<int> DownloadPaidMessages(KeyValuePair<bool, Dictionary<string, int>> hasSelectedUsersKVP, KeyValuePair<string, int> user, int paidMessagesCount, string path)
@@ -1482,7 +1485,8 @@ public class Program
                             ( "[red]RenameExistingFilesOnCustomFormat[/]", Config.RenameExistingFilesWhenCustomFormatIsSelected ),
                             ( "[red]DownloadPostsBeforeOrAfterSpecificDate[/]", Config.DownloadOnlySpecificDates ),
                             ( "[red]ShowScrapeSize[/]", Config.ShowScrapeSize),
-                            ( "[red]DownloadPostsIncrementally[/]", Config.DownloadPostsIncrementally)
+                            ( "[red]DownloadPostsIncrementally[/]", Config.DownloadPostsIncrementally),
+                            ( "[red]NonInteractiveMode[/]", Config.NonInteractiveMode)
                         });
 
                         MultiSelectionPrompt<string> multiSelectionPrompt = new MultiSelectionPrompt<string>()
@@ -1512,6 +1516,7 @@ public class Program
                             DownloadDateSelection = Config.DownloadDateSelection,
                             CustomDate = Config.CustomDate,
                             Timeout = Config.Timeout,
+                            FFmpegPath = Config.FFmpegPath,
                             DownloadAvatarHeaderPhoto = configOptions.Contains("[red]DownloadAvatarHeaderPhoto[/]"),
                             DownloadPaidPosts = configOptions.Contains("[red]DownloadPaidPosts[/]"),
                             DownloadPosts = configOptions.Contains("[red]DownloadPosts[/]"),
@@ -1534,7 +1539,8 @@ public class Program
                             RenameExistingFilesWhenCustomFormatIsSelected = configOptions.Contains("[red]RenameExistingFilesOnCustomFormat[/]"),
                             DownloadOnlySpecificDates = configOptions.Contains("[red]DownloadPostsBeforeOrAfterSpecificDate[/]"),
                             ShowScrapeSize = configOptions.Contains("[red]ShowScrapeSize[/]"),
-                            DownloadPostsIncrementally = configOptions.Contains("[red]DownloadPostsIncrementally[/]")
+                            DownloadPostsIncrementally = configOptions.Contains("[red]DownloadPostsIncrementally[/]"),
+                            NonInteractiveMode = configOptions.Contains("[red]NonInteractiveMode[/]")
                         };
 
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,6 +48,7 @@ if [ ! -f /config/config.json ]; then
 		  "CustomDate": "",
 		  "ShowScrapeSize": false,
 		  "DownloadPostsIncrementally": false,
+		  "NonInteractiveMode": false,
 		  "FFmpegPath": "/usr/bin/ffmpeg"
 		}
 	EOF


### PR DESCRIPTION
This PR adds the ability (by setting `NonInteractiveMode` to `true` in the config) for OF-DL to be run without requiring user interaction. In combination with the docker configuration, this will allow systems to automatically run OF-DL on a schedule. For instance, I run an OF-DL docker container on my unraid server. I have a scheduler start the container daily to automatically download content.

Future improvements could include adding optional notification options. For instance, a notification could be sent to configured notifiers when auth fails, DRM decryption fails, etc. I personally like the way [charlocharlie/epicgames-freegames](https://hub.docker.com/r/charlocharlie/epicgames-freegames) handles notifications. That project could be used as a template for setting up notifiers