### PR TITLE
Fix unescaped backslashes and drm download deadlock

### DIFF
--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -596,7 +596,7 @@ public class DownloadHelper : IDownloadHelper
             Arguments = $"-cenc_decryption_key {decKey} -headers \"Cookie:CloudFront-Policy={policy}; CloudFront-Signature={signature}; CloudFront-Key-Pair-Id={kvp}; {sess}\r\nOrigin: https://onlyfans.com\r\nReferer: https://onlyfans.com\r\nUser-Agent: {user_agent}\r\n\r\n\" -i \"{url}\" -codec copy \"{tempFilename}\"",
             CreateNoWindow = true,
             UseShellExecute = false,
-            RedirectStandardOutput = true,
+            RedirectStandardOutput = false,
             RedirectStandardError = true
         };
 
@@ -605,7 +605,14 @@ public class DownloadHelper : IDownloadHelper
             StartInfo = ffmpegStartInfo
         };
         ffmpegProcess.Start();
+        var ffmpegErrors = ffmpegProcess.StandardError.ReadToEnd();
         ffmpegProcess.WaitForExit();
+
+        if (ffmpegProcess.ExitCode != 0)
+        {
+            Console.WriteLine("\nFFmpeg failed to download {0}", url);
+            Log.Error(ffmpegErrors);
+        }
 
         if (File.Exists(tempFilename))
         {

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -12,6 +12,7 @@ using OF_DL.Helpers;
 using Serilog;
 using Spectre.Console;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using static OF_DL.Entities.Lists.UserList;
 
@@ -122,6 +123,12 @@ public class Program
                 else
                 {
                     AnsiConsole.Markup($"[green]FFmpeg located successfully\n[/]");
+                }
+
+                // Escape backslashes in the path for Windows
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && Config.FFmpegPath!.Contains(@":\") && !Config.FFmpegPath.Contains(@":\\"))
+                {
+                    Config.FFmpegPath = Config.FFmpegPath.Replace(@"\", @"\\");
                 }
             }
             else

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -98,7 +98,7 @@ public class Program
                     // FFmpeg is found in the PATH or current directory
                     ffmpegFound = true;
                     pathAutoDetected = true;
-                    Config.FFmpegPath = ffmpegPath.Replace(@"\", @"/");
+                    Config.FFmpegPath = ffmpegPath;
                 }
                 else
                 {
@@ -109,7 +109,7 @@ public class Program
                         // FFmpeg windows executable is found in the PATH or current directory
                         ffmpegFound = true;
                         pathAutoDetected = true;
-                        Config.FFmpegPath = ffmpegPath.Replace(@"\", @"/");
+                        Config.FFmpegPath = ffmpegPath;
                     }
                 }
             }


### PR DESCRIPTION
This PR includes a cross platform fix for the FFmpeg process deadlock. According to the docs, a deadlock can occur when redirecting standard error or standard output if it is not read (before calling WaitForExit).

The backslash escaping code just improves on your hotfix to only affect windows and to also fix an unescaped (if possible) path set by the user in config.