### PR TITLE
Change dynamic rules source

### DIFF
--- a/OF DL/Entities/DynamicRules.cs
+++ b/OF DL/Entities/DynamicRules.cs
@@ -1,21 +1,25 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Newtonsoft.Json;
 
 namespace OF_DL.Entities
 {
     public class DynamicRules
     {
-        public string? static_param { get; set; }
-        public string? start { get; set; }
-        public string? end { get; set; }
-        public int? checksum_constant { get; set; }
-        public List<int>? checksum_indexes { get; set; }
-        public string? app_token { get; set; }
-        public List<string>? remove_headers { get; set; }
-        public string? revision { get; set; }
-        public bool? is_current { get; set; }
+        [JsonProperty(PropertyName="app-token")]
+        public string? AppToken { get; set; }
+
+        [JsonProperty(PropertyName="static_param")]
+        public string? StaticParam { get; set; }
+
+        [JsonProperty(PropertyName="prefix")]
+        public string? Prefix { get; set; }
+
+        [JsonProperty(PropertyName="suffix")]
+        public string? Suffix { get; set; }
+
+        [JsonProperty(PropertyName="checksum_constant")]
+        public int? ChecksumConstant { get; set; }
+
+        [JsonProperty(PropertyName = "checksum_indexes")]
+        public List<int> ChecksumIndexes { get; set; }
     }
 }

--- a/OF DL/Helpers/Constants.cs
+++ b/OF DL/Helpers/Constants.cs
@@ -3,5 +3,5 @@ namespace OF_DL.Helpers;
 public static class Constants
 {
     public const string API_URL = "https://onlyfans.com/api2/v2";
-    public const string DYNAMIC_RULES = "https://raw.githubusercontent.com/deviint/onlyfans-dynamic-rules/main/dynamicRules.json";
+    public const string DYNAMIC_RULES = "https://raw.githubusercontent.com/SneakyOvis/onlyfans-dynamic-rules/main/rules.json";
 }


### PR DESCRIPTION
This PR changes the source of the OnlyFans dynamic rules from [deviint/onlyfans-dynamic-rules](https://github.com/deviint/onlyfans-dynamic-rules) to [SneakyOvis/onlyfans-dynamic-rules](https://github.com/SneakyOvis/onlyfans-dynamic-rules).

The new source uses GitHub Actions to automatically update the dynamic rules every 15 minutes if there are any changes. As a bonus, the source code is publicly available which isn't the case with the current source.