### PR TITLE
Use GitHub actions to publish docker images

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,43 @@
+﻿name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - 'OFDLV*'
+
+jobs:
+  push_to_registry:
+    name: Push docker image to registry
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version
+        id: version
+        run: |
+          VERSION="${GITHUB_REF_NAME#OFDLV}"
+          echo "Version: $VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.actor }}/of-dl:latest
+            ghcr.io/${{ github.actor }}/of-dl:${{ steps.version.outputs.version }}


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to automatically publish docker images to GitHub Container Registry (ghcr) when a new release tag is pushed. Whenever a tag is pushed with the `OFDLV` prefix, a docker image is built and pushed to both the latest tag and the version tag. For example, if the `OFDLV1.9.3` tag is pushed, `ghcr.io/sim0n00ps/of-dl:latest` and `ghcr.io/sim0n00ps/of-dl:1.9.3` will be pushed to ghcr.

Unless you've changed the repository's GitHub Actions settings to non-default values, only one setting will need to be updated to support this PR. On the [Actions (General) page](https://github.com/sim0n00ps/OF-DL/settings/actions), under `Workflow permissions`, be sure that `Read and write permissions` is selected. This will ensure that the GITHUB_TOKEN used by the workflow has permission to write to your packages.