### PR TITLE
More error handling

### DIFF
--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -58,7 +58,7 @@ public class Program
                     Console.Write("Press any key to continue.\n");
                     Log.Error("Windows version prior to 10.x: {0}", os.VersionString);
                     Console.ReadKey();
-                    Environment.Exit(0);
+                    Environment.Exit(1);
                 }
                 else
                 {
@@ -82,7 +82,7 @@ public class Program
                     AnsiConsole.MarkupLine($"[red]Press any key to exit.[/]");
                     Log.Error("auth.json processing failed.");
                     Console.ReadKey();
-                    Environment.Exit(0);
+                    Environment.Exit(2);
                 }
             }
             else
@@ -91,7 +91,7 @@ public class Program
                 AnsiConsole.Markup("[red]auth.json does not exist, a default file has been created in the folder you are running the program from[/]");
                 Log.Error("auth.json does not exist");
                 Console.ReadKey();
-                Environment.Exit(0);
+                Environment.Exit(2);
             }
 
             if (File.Exists("config.json"))
@@ -110,7 +110,7 @@ public class Program
                     AnsiConsole.MarkupLine($"[red]Press any key to exit.[/]");
                     Log.Error("config.json processing failed.");
                     Console.ReadKey();
-                    Environment.Exit(0);
+                    Environment.Exit(3);
                 }
             }
             else
@@ -119,7 +119,7 @@ public class Program
                 AnsiConsole.Markup("[red]config.json does not exist, a default file has been created in the folder you are running the program from[/]");
                 Log.Error("config.json does not exist");
                 Console.ReadKey();
-                Environment.Exit(0);
+                Environment.Exit(3);
             }
 
             var ffmpegFound = false;
@@ -182,7 +182,7 @@ public class Program
                 AnsiConsole.Markup("[red]Cannot locate FFmpeg; please modify config.json with the correct path. Press any key to exit.[/]");
                 Log.Error($"Cannot locate FFmpeg with path: {Config.FFmpegPath}");
                 Console.ReadKey();
-                Environment.Exit(0);
+                Environment.Exit(4);
             }
 
             if (!File.Exists("cdm/devices/chrome_1610/device_client_id_blob"))
@@ -243,6 +243,9 @@ public class Program
                 Console.WriteLine("Exception caught: {0}\n\nStackTrace: {1}", ex.InnerException.Message, ex.InnerException.StackTrace);
                 Log.Error("Inner Exception: {0}\n\nStackTrace: {1}", ex.InnerException.Message, ex.InnerException.StackTrace);
             }
+            Console.WriteLine("\nPress any key to exit.");
+            Console.ReadKey();
+            Environment.Exit(5);
         }
     }
 


### PR DESCRIPTION
* Update various `Environment.Exit()` calls to use non-zero exit codes to properly indicate a failure.
* In the primary `catch {}` block of the `Main()` function, wait for user keypress before exiting, so users have a chance to see the error if they are not running it underneath an existing console window.