### PR TITLE
Deal with purchased content from creators who no longer have an account.

### DIFF
--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -1852,7 +1852,13 @@ public class APIHelper : IAPIHelper
                         else
                         {
                             JObject user = await GetUserInfoById($"/users/list?x[]={purchase.fromUser.id}");
-                            if (!string.IsNullOrEmpty(user[purchase.fromUser.id.ToString()]["username"].ToString()))
+
+                            if(user is null)
+                            {
+                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
+                            }
+                            else if (!string.IsNullOrEmpty(user[purchase.fromUser.id.ToString()]["username"].ToString()))
                             {
                                 if (!purchasedTabUsers.ContainsKey(user[purchase.fromUser.id.ToString()]["username"].ToString()))
                                 {
@@ -1890,7 +1896,13 @@ public class APIHelper : IAPIHelper
                         else
                         {
                             JObject user = await GetUserInfoById($"/users/list?x[]={purchase.author.id}");
-                            if (!string.IsNullOrEmpty(user[purchase.author.id.ToString()]["username"].ToString()))
+
+                            if (user is null)
+                            {
+                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
+                            }
+                            else if (!string.IsNullOrEmpty(user[purchase.author.id.ToString()]["username"].ToString()))
                             {
                                 if (!purchasedTabUsers.ContainsKey(user[purchase.author.id.ToString()]["username"].ToString()) && users.ContainsKey(user[purchase.author.id.ToString()]["username"].ToString()))
                                 {
@@ -2001,7 +2013,7 @@ public class APIHelper : IAPIHelper
                 PurchasedTabCollection purchasedTabCollection = new PurchasedTabCollection();
                 JObject userObject = await GetUserInfoById($"/users/list?x[]={user.Key}");
                 purchasedTabCollection.UserId = user.Key;
-                purchasedTabCollection.Username = !string.IsNullOrEmpty(userObject[user.Key.ToString()]["username"].ToString()) ? userObject[user.Key.ToString()]["username"].ToString() : $"Deleted User - {user.Key}";
+                purchasedTabCollection.Username = userObject is not null && !string.IsNullOrEmpty(userObject[user.Key.ToString()]["username"].ToString()) ? userObject[user.Key.ToString()]["username"].ToString() : $"Deleted User - {user.Key}";
                 string path = System.IO.Path.Combine(folder, purchasedTabCollection.Username);
                 if (Path.Exists(path))
                 {


### PR DESCRIPTION
When a content creator no longer has an account, the purchased content still exists, but GetUserInfoById() cannot retrieve their info. So this fix just treats them the same as way as if you no longer have an active subscription... created the "Deleted User" folder.

If you want I'll add an extra config setting to allow people to bypass content from creators who no longer have an account.