### PR TITLE
Add option to bypass missing creator content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,7 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/OF DL/auth.json
+/OF DL/config.json
+/OF DL/device_client_id_blob
+/OF DL/device_private_key

--- a/OF DL/CDMApi.cs
+++ b/OF DL/CDMApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace WidevineClient.Widevine
@@ -9,7 +9,7 @@ namespace WidevineClient.Widevine
 
         public byte[] GetChallenge(string initDataB64, string certDataB64, bool offline = false, bool raw = false)
         {
-            SessionId = CDM.OpenSession(initDataB64, "chrome_1610", offline, raw);
+            SessionId = CDM.OpenSession(initDataB64, Constants.DEVICE_NAME, offline, raw);
             CDM.SetServiceCertificate(SessionId, Convert.FromBase64String(certDataB64));
             return CDM.GetLicenseRequest(SessionId);
         }

--- a/OF DL/Entities/Config.cs
+++ b/OF DL/Entities/Config.cs
@@ -81,6 +81,9 @@ namespace OF_DL.Entities
         public bool NonInteractiveModePurchasedTab { get; set; } = false;
         public string? FFmpegPath { get; set; } = string.Empty;
 
+        [ToggleableConfig]
+        public bool BypassContentForCreatorsWhoNoLongerExist { get; set; } = false;
+
         public Dictionary<string, CreatorConfig> CreatorConfigs { get; set; } = new Dictionary<string, CreatorConfig>();
     }
 

--- a/OF DL/Entities/IDownloadConfig.cs
+++ b/OF DL/Entities/IDownloadConfig.cs
@@ -1,4 +1,4 @@
-﻿using OF_DL.Enumerations;
+using OF_DL.Enumerations;
 
 namespace OF_DL.Entities
 {
@@ -30,6 +30,7 @@ namespace OF_DL.Entities
         string? FFmpegPath { get; set; }
 
         bool SkipAds { get; set; }
+        bool BypassContentForCreatorsWhoNoLongerExist { get; set; }
 
         #region Download Date Configurations
 

--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -1852,7 +1852,13 @@ public class APIHelper : IAPIHelper
                         else
                         {
                             JObject user = await GetUserInfoById($"/users/list?x[]={purchase.fromUser.id}");
-                            if (!string.IsNullOrEmpty(user[purchase.fromUser.id.ToString()]["username"].ToString()))
+
+                            if(user is null)
+                            {
+                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
+                            }
+                            else if (!string.IsNullOrEmpty(user[purchase.fromUser.id.ToString()]["username"].ToString()))
                             {
                                 if (!purchasedTabUsers.ContainsKey(user[purchase.fromUser.id.ToString()]["username"].ToString()))
                                 {
@@ -1890,7 +1896,13 @@ public class APIHelper : IAPIHelper
                         else
                         {
                             JObject user = await GetUserInfoById($"/users/list?x[]={purchase.author.id}");
-                            if (!string.IsNullOrEmpty(user[purchase.author.id.ToString()]["username"].ToString()))
+
+                            if (user is null)
+                            {
+                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
+                            }
+                            else if (!string.IsNullOrEmpty(user[purchase.author.id.ToString()]["username"].ToString()))
                             {
                                 if (!purchasedTabUsers.ContainsKey(user[purchase.author.id.ToString()]["username"].ToString()) && users.ContainsKey(user[purchase.author.id.ToString()]["username"].ToString()))
                                 {
@@ -2001,7 +2013,7 @@ public class APIHelper : IAPIHelper
                 PurchasedTabCollection purchasedTabCollection = new PurchasedTabCollection();
                 JObject userObject = await GetUserInfoById($"/users/list?x[]={user.Key}");
                 purchasedTabCollection.UserId = user.Key;
-                purchasedTabCollection.Username = !string.IsNullOrEmpty(userObject[user.Key.ToString()]["username"].ToString()) ? userObject[user.Key.ToString()]["username"].ToString() : $"Deleted User - {user.Key}";
+                purchasedTabCollection.Username = userObject is not null && !string.IsNullOrEmpty(userObject[user.Key.ToString()]["username"].ToString()) ? userObject[user.Key.ToString()]["username"].ToString() : $"Deleted User - {user.Key}";
                 string path = System.IO.Path.Combine(folder, purchasedTabCollection.Username);
                 if (Path.Exists(path))
                 {

--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -239,6 +239,13 @@ public class APIHelper : IAPIHelper
 
             response.EnsureSuccessStatusCode();
             var body = await response.Content.ReadAsStringAsync();
+
+            //if the content creator doesnt exist, we get a 200 response, but the content isnt usable
+            //so let's not throw an exception, since "content creator no longer exists" is handled elsewhere
+            //which means we wont get loads of exceptions
+            if (body.Equals("[]"))
+                return null;
+
             JObject jObject = JObject.Parse(body);
 
             return jObject;
@@ -1855,7 +1862,10 @@ public class APIHelper : IAPIHelper
 
                             if(user is null)
                             {
-                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                if (!config.BypassContentForCreatorsWhoNoLongerExist)
+                                {
+                                    purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                }
                                 Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
                             }
                             else if (!string.IsNullOrEmpty(user[purchase.fromUser.id.ToString()]["username"].ToString()))
@@ -1899,7 +1909,10 @@ public class APIHelper : IAPIHelper
 
                             if (user is null)
                             {
-                                purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                if (!config.BypassContentForCreatorsWhoNoLongerExist)
+                                {
+                                    purchasedTabUsers.Add($"Deleted User - {purchase.fromUser.id}", purchase.fromUser.id);
+                                }
                                 Log.Information("Content creator not longer exists - {0}", purchase.fromUser.id);
                             }
                             else if (!string.IsNullOrEmpty(user[purchase.author.id.ToString()]["username"].ToString()))

--- a/OF DL/OF DL.csproj
+++ b/OF DL/OF DL.csproj
@@ -31,4 +31,13 @@
     </Reference>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="auth.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="rules.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -221,7 +221,7 @@ public class Program
                 }
             }
 
-            if (!File.Exists("cdm/devices/chrome_1610/device_client_id_blob"))
+            if (!File.Exists(Path.Join(WidevineClient.Widevine.Constants.DEVICES_FOLDER, WidevineClient.Widevine.Constants.DEVICE_NAME, "device_client_id_blob")))
             {
                 clientIdBlobMissing = true;
             }
@@ -230,7 +230,7 @@ public class Program
                 AnsiConsole.Markup($"[green]device_client_id_blob located successfully![/]\n");
             }
 
-            if (!File.Exists("cdm/devices/chrome_1610/device_private_key"))
+            if (!File.Exists(Path.Join(WidevineClient.Widevine.Constants.DEVICES_FOLDER, WidevineClient.Widevine.Constants.DEVICE_NAME, "device_private_key")))
             {
                 devicePrivateKeyMissing = true;
             }

--- a/OF DL/Widevine/CDM.cs
+++ b/OF DL/Widevine/CDM.cs
@@ -1,4 +1,4 @@
-﻿using ProtoBuf;
+using ProtoBuf;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -14,7 +14,7 @@ namespace WidevineClient.Widevine
     {
         static Dictionary<string, CDMDevice> Devices { get; } = new Dictionary<string, CDMDevice>()
         {
-            ["chrome_1610"] = new CDMDevice("chrome_1610", null, null, null)
+            [Constants.DEVICE_NAME] = new CDMDevice(Constants.DEVICE_NAME, null, null, null)
         };
         static Dictionary<string, Session> Sessions { get; set; } = new Dictionary<string, Session>();
 

--- a/OF DL/Widevine/Constants.cs
+++ b/OF DL/Widevine/Constants.cs
@@ -1,8 +1,9 @@
-﻿namespace WidevineClient.Widevine
+namespace WidevineClient.Widevine
 {
     public class Constants
     {
         public static string WORKING_FOLDER { get; set; } = System.IO.Path.GetFullPath(System.IO.Path.Join(System.IO.Directory.GetCurrentDirectory(), "cdm"));
         public static string DEVICES_FOLDER { get; set; } = System.IO.Path.GetFullPath(System.IO.Path.Join(WORKING_FOLDER, "devices"));
+        public static string DEVICE_NAME { get; set; } = "chrome_1610";
     }
 }


### PR DESCRIPTION
Add an option to bypass downloading purchased content for creators who no longer exist. Useful if you already have their content, and dont want to redownload it all as "deleted user - {ID}".

Also added a small improvement to handle users who no longer exist.

It was very difficult to test this properly, as I had to manipulate data in-memory at the right points... 