### PR TITLE
Fix erroneous filename of downloaded profile header

### DIFF
--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -839,8 +839,7 @@ public class DownloadHelper : IDownloadHelper
                 List<string> headerMD5Hashes = WidevineClient.Utils.CalculateFolderMD5(folder + headerpath);
 
                 Uri uri = new(headerUrl);
-                string filename = System.IO.Path.GetFileName(uri.LocalPath);
-                string destinationPath = $"{folder}{headerpath}/{filename}";
+                string destinationPath = $"{folder}{headerpath}/";
 
                 var client = new HttpClient();
 
@@ -870,7 +869,6 @@ public class DownloadHelper : IDownloadHelper
                     }
                     File.SetLastWriteTime(destinationPath, response.Content.Headers.LastModified?.LocalDateTime ?? DateTime.Now);
                 }
-
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Fixes #421. Upon investigation, it was indeed an oversight.

By the way, in this `DownloadAvatarHeader` method, the codes for the avatar and for the header are nearly identical. There is some potential for code factorization here.