### PR TITLE
fix: ffmpeg always overwrite existing if it exists

### DIFF
--- a/OF DL/Helpers/DownloadHelper.cs
+++ b/OF DL/Helpers/DownloadHelper.cs
@@ -597,7 +597,7 @@ public class DownloadHelper : IDownloadHelper
         ProcessStartInfo ffmpegStartInfo = new()
         {
             FileName = downloadConfig.FFmpegPath,
-            Arguments = $"-cenc_decryption_key {decKey} -headers \"Cookie:CloudFront-Policy={policy}; CloudFront-Signature={signature}; CloudFront-Key-Pair-Id={kvp}; {sess}\r\nOrigin: https://onlyfans.com\r\nReferer: https://onlyfans.com\r\nUser-Agent: {user_agent}\r\n\r\n\" -i \"{url}\" -codec copy \"{tempFilename}\"",
+            Arguments = $"-cenc_decryption_key {decKey} -headers \"Cookie:CloudFront-Policy={policy}; CloudFront-Signature={signature}; CloudFront-Key-Pair-Id={kvp}; {sess}\r\nOrigin: https://onlyfans.com\r\nReferer: https://onlyfans.com\r\nUser-Agent: {user_agent}\r\n\r\n\" -y -i \"{url}\" -codec copy \"{tempFilename}\"",
             CreateNoWindow = true,
             UseShellExecute = false,
             RedirectStandardOutput = false,


### PR DESCRIPTION
I had a stray file, and it got all the way to FFMpeg to download the media, but the program got stuck.
FFMpeg was waiting for a input response to overwrite an existing file. 

This just adds the `-y` command line parameter to signal the yes.