### PR TITLE
Add arm64 support for Docker

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/${{ github.actor }}/of-dl:latest


### PR DESCRIPTION
Macs using Apple Silicon are on an ARM chip rather than a x64 chip. This addiction pushes both `amd64` and `arm64` Docker images when a new release is created, so the instructions on how to use them remain the same, it'll just work correctly for those users.