### PR TITLE
Print program version on start-up

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           tags: |
             ghcr.io/${{ github.actor }}/of-dl:latest
             ghcr.io/${{ github.actor }}/of-dl:${{ steps.version.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
 
+ARG VERSION
+
 # Copy source code
 COPY ["OF DL.sln", "/src/OF DL.sln"]
 COPY ["OF DL", "/src/OF DL"]
@@ -7,7 +9,7 @@ COPY ["OF DL", "/src/OF DL"]
 WORKDIR "/src"
 
 # Build release
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -p Version=$VERSION -c Release -o out
 
 
 FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy

--- a/OF DL/OF DL.csproj
+++ b/OF DL/OF DL.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Icon\download.ico</ApplicationIcon>
-    <Version>1.7.61</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OF DL/OF DL.csproj
+++ b/OF DL/OF DL.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Icon\download.ico</ApplicationIcon>
+    <Version>1.7.61</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -39,7 +39,11 @@ public class Program
 
             AnsiConsole.Write(new FigletText("Welcome to OF-DL").Color(Color.Red));
 
-
+            var version = Assembly.GetEntryAssembly()?.GetName().Version;
+            if (version != null)
+            {
+                AnsiConsole.Markup("[green]Version: " + $"{version.Major}.{version.Minor}.{version.Build}\n[/]");
+            }
 
             if (args is not null && args.Length > 0)
             {


### PR DESCRIPTION
I've noticed in discord that users frequently confused about their program version. Also, users frequently post screenshots of their console output. By printing the program version on start-up, a lot of common back-and-forth in discord can be eliminated.

A downside of this functionality, though, ~~is that you will need to manually update the version in `OF DL/OF DL.csproj` before each release.~~ is that you'll need to use an additional build argument when building releases (e.g. `-p Version=1.7.61`). I personally think the trade-off is worth it, but I won't be the one updating the version each time :laughing: 

In the future, a config option can be added to automatically check for updates. A github API request could be made to compare the current program version to the most recent release on github.