### PR TITLE
feat: change Dockerfile to use alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0 as build
+FROM alpine as build
 
 ARG VERSION
+
+RUN apk --repository community add dotnet8-sdk
 
 # Copy source code
 COPY ["OF DL.sln", "/src/OF DL.sln"]
@@ -11,15 +13,10 @@ WORKDIR "/src"
 # Build release
 RUN dotnet publish -p:Version=$VERSION -c Release --self-contained true -p:PublishSingleFile=true -o out
 
-
-FROM mcr.microsoft.com/dotnet/runtime:7.0-jammy
+FROM alpine as final
 
 # Install dependencies
-RUN apt-get update
-RUN apt-get install -y software-properties-common
-RUN add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
-RUN apt-get update
-RUN apt-get install -y ffmpeg
+RUN apk --repository community add ffmpeg bash dotnet8-runtime bash
 
 # Copy release and entrypoint script
 COPY --from=build /src/out /app


### PR DESCRIPTION
Changed over to use alpine since it supports dotnet8 and ffmepg without adding a ppa.

Tested it with both docker and podman, builds without an issue. 