### PR TITLE
Docker improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mv /src/updated_config.json /src/config.json
 FROM alpine:3.20 AS final
 
 # Install dependencies
-RUN apk --repository community add ffmpeg bash dotnet8-runtime bash
+RUN apk --repository community add ffmpeg bash dotnet8-runtime tini
 
 # Copy release and entrypoint script
 COPY --from=build /src/out /app
@@ -45,5 +45,5 @@ COPY --from=build /src/config.json /default-config
 COPY --from=build /src/auth.json /default-config
 
 WORKDIR /config
-CMD /app/entrypoint.sh
+ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM alpine:3.20 AS build
 
 ARG VERSION
 
-RUN apk --repository community add dotnet8-sdk jq
+RUN apk --no-cache --repository community add \
+      dotnet8-sdk==8.0.107-r0 \
+      jq==1.7.1-r0
 
 # Copy source code
 COPY ["OF DL.sln", "/src/OF DL.sln"]
@@ -14,35 +16,37 @@ WORKDIR "/src"
 RUN dotnet publish -p:Version=$VERSION -c Release --self-contained true -p:PublishSingleFile=true -o out
 
 # Generate default auth.json and config.json files
-RUN /src/out/OF\ DL --non-interactive || true
-RUN /src/out/OF\ DL --non-interactive || true
-
+RUN /src/out/OF\ DL --non-interactive || true && \
+      /src/out/OF\ DL --non-interactive || true && \
 # Remove FFMPEG_PATH (deprecated) from default auth.json
-RUN jq 'del(.FFMPEG_PATH)' /src/auth.json > /src/updated_auth.json
-RUN mv /src/updated_auth.json /src/auth.json
-
+      jq 'del(.FFMPEG_PATH)' /src/auth.json > /src/updated_auth.json && \
+      mv /src/updated_auth.json /src/auth.json && \
 # Set download path in default config.json to /data
-RUN jq '.DownloadPath = "/data"' /src/config.json > /src/updated_config.json
-RUN mv /src/updated_config.json /src/config.json
+      jq '.DownloadPath = "/data"' /src/config.json > /src/updated_config.json && \
+      mv /src/updated_config.json /src/config.json
 
 
 FROM alpine:3.20 AS final
 
 # Install dependencies
-RUN apk --repository community add ffmpeg bash dotnet8-runtime tini
+RUN apk --no-cache --repository community add \
+      bash==5.2.26-r0 \
+      tini==0.19.0-r3 \
+      dotnet8-runtime==8.0.7-r0 \
+      ffmpeg==6.1.1-r8
 
 # Copy release and entrypoint script
 COPY --from=build /src/out /app
-ADD docker/entrypoint.sh /app
-RUN chmod +x /app/entrypoint.sh
 
-RUN mkdir /data  # For downloaded files
-RUN mkdir /config  # For configuration files
-RUN mkdir /default-config  # For default configuration files
+# Create directories for configuration and downloaded files
+RUN mkdir /data /config /default-config
 
 # Copy default configuration files
 COPY --from=build /src/config.json /default-config
 COPY --from=build /src/auth.json /default-config
+
+COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 WORKDIR /config
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN mkdir /data /config /default-config
 # Copy default configuration files
 COPY --from=build /src/config.json /default-config
 COPY --from=build /src/auth.json /default-config
+COPY --from=build ["/src/OF DL/rules.json", "/default-config"]
 
 COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as build
+FROM alpine:3.20 AS build
 
 ARG VERSION
 
@@ -13,7 +13,6 @@ WORKDIR "/src"
 # Build release
 RUN dotnet publish -p:Version=$VERSION -c Release --self-contained true -p:PublishSingleFile=true -o out
 
-FROM alpine as final
 # Generate default auth.json and config.json files
 RUN /src/out/OF\ DL --non-interactive || true
 RUN /src/out/OF\ DL --non-interactive || true
@@ -26,6 +25,8 @@ RUN mv /src/updated_auth.json /src/auth.json
 RUN jq '.DownloadPath = "/data"' /src/config.json > /src/updated_config.json
 RUN mv /src/updated_config.json /src/config.json
 
+
+FROM alpine:3.20 AS final
 
 # Install dependencies
 RUN apk --repository community add ffmpeg bash dotnet8-runtime bash

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -10,4 +10,8 @@ if [ ! -f /config/config.json ]; then
 	cp /default-config/config.json /config/config.json
 fi
 
+if [ ! -f /config/rules.json ]; then
+	cp /default-config/rules.json /config/rules.json
+fi
+
 /app/OF\ DL

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,57 +3,11 @@
 mkdir -p /config/cdm/devices/chrome_1610
 
 if [ ! -f /config/auth.json ]; then
-	cat > /config/auth.json <<- EOF
-		{
-		  "USER_ID": "",
-		  "USER_AGENT": "",
-		  "X_BC": "",
-		  "COOKIE": ""
-		}
-	EOF
+	cp /default-config/auth.json /config/auth.json
 fi
 
 if [ ! -f /config/config.json ]; then
-	cat > /config/config.json <<- EOF
-		{
-		  "DownloadAvatarHeaderPhoto": true,
-		  "DownloadPaidPosts": true,
-		  "DownloadPosts": true,
-		  "DownloadArchived": true,
-		  "DownloadStreams": true,
-		  "DownloadStories": true,
-		  "DownloadHighlights": true,
-		  "DownloadMessages": true,
-		  "DownloadPaidMessages": true,
-		  "DownloadImages": true,
-		  "DownloadVideos": true,
-		  "DownloadAudios": true,
-		  "IncludeExpiredSubscriptions": true,
-		  "IncludeRestrictedSubscriptions": true,
-		  "SkipAds": false,
-		  "DownloadPath": "/data/",
-		  "PaidPostFileNameFormat": "",
-		  "PostFileNameFormat": "",
-		  "PaidMessageFileNameFormat": "",
-		  "MessageFileNameFormat": "",
-		  "RenameExistingFilesWhenCustomFormatIsSelected": true,
-		  "Timeout": null,
-		  "FolderPerPaidPost": false,
-		  "FolderPerPost": false,
-		  "FolderPerPaidMessage": false,
-		  "FolderPerMessage": false,
-		  "LimitDownloadRate": false,
-		  "DownloadLimitInMbPerSec": 4,
-		  "DownloadOnlySpecificDates": false,
-		  "DownloadDateSelection": "after",
-		  "CustomDate": "",
-		  "ShowScrapeSize": false,
-		  "DownloadPostsIncrementally": false,
-		  "NonInteractiveMode": false,
-		  "FFmpegPath": "/usr/bin/ffmpeg"
-		}
-	EOF
+	cp /default-config/config.json /config/config.json
 fi
 
 /app/OF\ DL
-


### PR DESCRIPTION
This PR makes 3 changes

- Automatically generate default `auth.json` and `config.json` files similar to the windows build process instead of using the previously hard-coded values
- Specify the alpine version (should help to maintain consistent builds in the future when alpine has a new version)
- Add the [tini init system](https://github.com/krallin/tini) as a best practice for containers