### PR TITLE
fix: parse rawTax from text is missing

### DIFF
--- a/OF DL/Entities/Archived/Archived.cs
+++ b/OF DL/Entities/Archived/Archived.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using OF_DL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -82,7 +83,23 @@ namespace OF_DL.Entities.Archived
             public object expiredAt { get; set; }
             public Author author { get; set; }
             public string text { get; set; }
-            public string rawText { get; set; }
+            private string _rawText;
+            public string rawText
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(_rawText))
+                    {
+                        _rawText = XmlUtils.EvaluateInnerText(text);
+                    }
+
+                    return _rawText;
+                }
+                set
+                {
+                    _rawText = value;
+                }
+            }
             public bool? lockedText { get; set; }
             public bool? isFavorite { get; set; }
             public bool? canReport { get; set; }
@@ -124,7 +141,23 @@ namespace OF_DL.Entities.Archived
             public object expiredAt { get; set; }
             public Author author { get; set; }
             public string text { get; set; }
-            public string rawText { get; set; }
+            private string _rawText;
+            public string rawText
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(_rawText))
+                    {
+                        _rawText = XmlUtils.EvaluateInnerText(text);
+                    }
+
+                    return _rawText;
+                }
+                set
+                {
+                    _rawText = value;
+                }
+            }
             public bool? lockedText { get; set; }
             public bool? isFavorite { get; set; }
             public bool? canReport { get; set; }

--- a/OF DL/Entities/Post/Post.cs
+++ b/OF DL/Entities/Post/Post.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using OF_DL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -74,7 +75,24 @@ public class Post
         public object expiredAt { get; set; }
         public Author author { get; set; }
         public string text { get; set; }
-        public string rawText { get; set; }
+
+        private string _rawText;
+        public string rawText
+        {
+            get
+            {
+                if(string.IsNullOrEmpty(_rawText))
+                {
+                    _rawText = XmlUtils.EvaluateInnerText(text);
+                }
+
+                return _rawText;
+            }
+            set
+            {
+                _rawText = value;
+            }
+        }
         public bool? lockedText { get; set; }
         public bool? isFavorite { get; set; }
         public bool? canReport { get; set; }

--- a/OF DL/Entities/Post/SinglePost.cs
+++ b/OF DL/Entities/Post/SinglePost.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using OF_DL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +17,23 @@ namespace OF_DL.Entities.Post
         public object expiredAt { get; set; }
         public Author author { get; set; }
         public string text { get; set; }
-        public string rawText { get; set; }
+        private string _rawText;
+        public string rawText
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(_rawText))
+                {
+                    _rawText = XmlUtils.EvaluateInnerText(text);
+                }
+
+                return _rawText;
+            }
+            set
+            {
+                _rawText = value;
+            }
+        }
         public bool lockedText { get; set; }
         public bool isFavorite { get; set; }
         public bool canReport { get; set; }

--- a/OF DL/Entities/Streams/Streams.cs
+++ b/OF DL/Entities/Streams/Streams.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using OF_DL.Utils;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -52,7 +53,23 @@ namespace OF_DL.Entities.Streams
             public object expiredAt { get; set; }
             public Author author { get; set; }
             public string text { get; set; }
-            public string rawText { get; set; }
+            private string _rawText;
+            public string rawText
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(_rawText))
+                    {
+                        _rawText = XmlUtils.EvaluateInnerText(text);
+                    }
+
+                    return _rawText;
+                }
+                set
+                {
+                    _rawText = value;
+                }
+            }
             public bool lockedText { get; set; }
             public bool isFavorite { get; set; }
             public bool canReport { get; set; }

--- a/OF DL/Utils/XmlUtils.cs
+++ b/OF DL/Utils/XmlUtils.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace OF_DL.Utils
+{
+    internal static class XmlUtils
+    {
+        public static string EvaluateInnerText(string xmlValue)
+        {
+            try
+            {
+                var parsedText = XElement.Parse($"<root>{xmlValue}</root>");
+                return parsedText.Value;
+            }
+            catch
+            { }
+
+            return string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
The API isn't returning `rawText` on some posts, so adding logic to parse it locally from the returned `text` value.