### PR TITLE
Change default value of ShowScrapeSize to false

### DIFF
--- a/OF DL/Entities/Config.cs
+++ b/OF DL/Entities/Config.cs
@@ -71,7 +71,7 @@ namespace OF_DL.Entities
         public DateTime? CustomDate { get; set; } = null;
 
         [ToggleableConfig]
-        public bool ShowScrapeSize { get; set; } = true;
+        public bool ShowScrapeSize { get; set; } = false;
 
         [ToggleableConfig]
         public bool DownloadPostsIncrementally { get; set; } = false;


### PR DESCRIPTION
I noticed while updating the docs that our default value for `ShowScrapeSize` is true. Prior to the automatic `config.json` (v1.7.61 and before), the default was false. We have warning about this in the docs, but due to the performance hit and potential rate limiting of this config option, I think the default should be false.
