### PR TITLE
Updating linux build instructions

### DIFF
--- a/LINUX_BUILD.md
+++ b/LINUX_BUILD.md
@@ -5,21 +5,20 @@
 
 ### Instructions
 
-- Install the libicu library  
-`sudo apt-get install libicu-dev`  
+- Install the libicu library
+`sudo apt-get install libicu-dev`
 
-- Install .NET version 7  
-`wget https://dot.net/v1/dotnet-install.sh`  
-`sudo bash dotnet-install.sh --architecture x64 --install-dir /usr/share/dotnet/ --runtime dotnet --version 7.0.19`  
+- Install .NET version 8
+`sudo apt-get install dotnet-sdk-8.0`
 
-- Clone the repo  
-`git clone https://github.com/sim0n00ps/OF-DL.git`  
-`cd 'OF-DL'`  
+- Clone the repo
+`git clone https://github.com/sim0n00ps/OF-DL.git`
+`cd 'OF-DL'`
 
-- Build the project  
-`dotnet build`  
-`cd 'OF DL/bin/Debug/net7.0'`  
+- Build the project
+`dotnet build`
+`cd 'OF DL/bin/Debug/net8.0'`
 
 - Add the .json files like stated in README.md
-- Run the application  
-`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 ./'OF DL'`
+- Run the application
+`./'OF DL'`


### PR DESCRIPTION
The dotnet version has changed, and the build instructions for linux systems needed to be updated