### PR TITLE
fix: some media json does not contain createdAt causing null exceptions

### DIFF
--- a/OF DL/Entities/Highlights/HighlightMedia.cs
+++ b/OF DL/Entities/Highlights/HighlightMedia.cs
@@ -41,7 +41,7 @@ namespace OF_DL.Entities.Highlights
 			public bool convertedToVideo { get; set; }
 			public bool canView { get; set; }
 			public bool hasError { get; set; }
-			public DateTime createdAt { get; set; }
+			public DateTime? createdAt { get; set; }
 			public Files files { get; set; }
 		}
 

--- a/OF DL/Entities/Post/SinglePost.cs
+++ b/OF DL/Entities/Post/SinglePost.cs
@@ -119,7 +119,7 @@ namespace OF_DL.Entities.Post
             public bool convertedToVideo { get; set; }
             public bool canView { get; set; }
             public bool hasError { get; set; }
-            public DateTime createdAt { get; set; }
+            public DateTime? createdAt { get; set; }
             public Info info { get; set; }
             public Source source { get; set; }
             public string squarePreview { get; set; }

--- a/OF DL/Entities/Stories/Stories.cs
+++ b/OF DL/Entities/Stories/Stories.cs
@@ -42,7 +42,7 @@ namespace OF_DL.Entities.Stories
             public bool convertedToVideo { get; set; }
             public bool canView { get; set; }
             public bool hasError { get; set; }
-            public DateTime createdAt { get; set; }
+            public DateTime? createdAt { get; set; }
             public Files files { get; set; }
         }
 

--- a/OF DL/Entities/Streams/Streams.cs
+++ b/OF DL/Entities/Streams/Streams.cs
@@ -139,7 +139,7 @@ namespace OF_DL.Entities.Streams
             public bool convertedToVideo { get; set; }
             public bool canView { get; set; }
             public bool hasError { get; set; }
-            public DateTime createdAt { get; set; }
+            public DateTime? createdAt { get; set; }
             public Info info { get; set; }
             public Source source { get; set; }
             public string squarePreview { get; set; }

--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -527,14 +527,8 @@ public class APIHelper : IAPIHelper
 
                 foreach (Stories story in stories)
                 {
-                    if (story.createdAt != null)
-                    {
-                        await m_DBHelper.AddStory(folder, story.id, string.Empty, "0", false, false, story.createdAt);
-                    }
-                    else
-                    {
-                        await m_DBHelper.AddStory(folder, story.id, string.Empty, "0", false, false, story.media[0].createdAt);
-                    }
+                    await m_DBHelper.AddStory(folder, story.id, string.Empty, "0", false, false, story.createdAt);
+                    
                     if (story.media != null && story.media.Count > 0)
                     {
                         foreach (Stories.Medium medium in story.media)


### PR DESCRIPTION
I had a couple creators come back with errors deserializing the json

```
2024-08-22 17:06:38.087 -05:00 [ERR] Inner Exception: Null object cannot be converted to a value type.

StackTrace:    at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.EnsureType(JsonReader reader, Object value, CultureInfo culture, JsonContract contract, Type targetType)
2024-08-22 17:06:38.804 -05:00 [ERR] Exception caught: Error converting value {null} to type 'System.DateTime'. Path 'stories[0].media[0].createdAt', line 1, position 1238.
```

Just making the createdAt nullable, so if it's not present in the JSON or NULL, it doesn't error.