### PR TITLE
Remove QEMU from docker image builds

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -16,11 +16,9 @@ jobs:
           VERSION="${GITHUB_REF_NAME#OFDLV}"
           echo "Version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,7 +31,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This seems to fix the multi-arch docker image builds. [According to Microsoft](https://devblogs.microsoft.com/dotnet/improving-multiplatform-container-support/), buildx is all we need to build multi-arch docker images. I was able to run the docker build GHA 10 times without any failures.