### PR TITLE
Cache the dynamic rules response 

### DIFF
--- a/OF DL/Helpers/APIHelper.cs
+++ b/OF DL/Helpers/APIHelper.cs
@@ -26,8 +26,8 @@ public class APIHelper : IAPIHelper
     private static readonly JsonSerializerSettings m_JsonSerializerSettings;
     private readonly IDBHelper m_DBHelper;
     private readonly Auth auth;
-    private DateTime? cachedDynamicRulesExpiration;
-    private DynamicRules? cachedDynamicRules;
+    private static DateTime? cachedDynamicRulesExpiration;
+    private static DynamicRules? cachedDynamicRules;
 
     static APIHelper()
     {


### PR DESCRIPTION
I noticed when looking through my debug log recently that OF-DL is making a lot of unnecessary network calls to retrieve the dynamic rules. This PR caches the dynamic rules from GitHub for 15 minutes and from local file for 5 minutes. Since the dynamic rules don't change often, the 15 minute cache should be just fine. The 5 minute cache when the dynamic rules are retrieved from the local file exists to limit the number of bad/failing requests to GitHub (which would be the cause for using the local file).