### PR TITLE
Fix docker login issue

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,15 +4,22 @@ mkdir -p /config/cdm/devices/chrome_1610
 mkdir -p /config/logs/
 
 if [ ! -f /config/config.conf ] && [ ! -f /config/config.json ]; then
-	cp /default-config/config.conf /config/config.conf
+  cp /default-config/config.conf /config/config.conf
 fi
 
 if [ ! -f /config/rules.json ]; then
-	cp /default-config/rules.json /config/rules.json
+  cp /default-config/rules.json /config/rules.json
 fi
 
 {
   supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 } &> /dev/null
+
+# Wait for the 3 supervisor programs to start: X11 (Xvfb), X11vnc, and noVNC
+NUM_RUNNING_SERVICES=$(supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status | grep RUNNING | wc -l)
+while [ $NUM_RUNNING_SERVICES != "3" ]; do
+  sleep 1
+  NUM_RUNNING_SERVICES=$(supervisorctl -c /etc/supervisor/conf.d/supervisord.conf status | grep RUNNING | wc -l)
+done
 
 /app/OF\ DL

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 mkdir -p /config/cdm/devices/chrome_1610
+mkdir -p /config/logs/
 
 if [ ! -f /config/config.conf ] && [ ! -f /config/config.json ]; then
 	cp /default-config/config.conf /config/config.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,6 +1,17 @@
+[unix_http_server]
+file=/tmp/supervisor.sock
+
 [supervisord]
 nodaemon=true
+user=root
 logfile=/config/logs/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
 
 [program:X11]
 command=Xvfb :0 -screen 0 "%(ENV_DISPLAY_WIDTH)s"x"%(ENV_DISPLAY_HEIGHT)s"x24


### PR DESCRIPTION
The cause of the browser login issues while using docker (mentioned in discord) was supervisord crashing when the logs directory doesn't exist. supervisord runs X11, X11vnc, and noVNC, so without it, the browser based login doesn't won't work while using docker. The solution was to just create the directory if it doesn't exist in the entrypoint script.

I also added an additional check to wait for the 3 programs to be in a running state before executing the OF-DL binary. The `user=root` line in the supervisord config is simply there to remove a notice that supervisord prints on each execution, and the pidfile configuration simply specifies a different filepath for the supervisord PID file to prevent it from being included in users' volumes.