### PR TITLE
Fix docker issue when specifying user and auth issue when chromium is closed

### DIFF
--- a/OF DL/Helpers/AuthHelper.cs
+++ b/OF DL/Helpers/AuthHelper.cs
@@ -67,8 +67,24 @@ public class AuthHelper
     {
         try
         {
-
-            await using IBrowser? browser = await Puppeteer.LaunchAsync(_options);
+            IBrowser? browser;
+            try
+            {
+                browser = await Puppeteer.LaunchAsync(_options);
+            }
+            catch (ProcessException e)
+            {
+                if (e.Message.Contains("Failed to launch browser") && Directory.Exists(_options.UserDataDir))
+                {
+                    Log.Error("Failed to launch browser. Deleting chrome-data directory and trying again.");
+                    Directory.Delete(_options.UserDataDir, true);
+                    browser = await Puppeteer.LaunchAsync(_options);
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             if (browser == null)
             {

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -3,7 +3,6 @@ file=/tmp/supervisor.sock
 
 [supervisord]
 nodaemon=true
-user=root
 logfile=/config/logs/supervisord.log
 pidfile=/var/run/supervisord.pid
 


### PR DESCRIPTION
Addresses https://github.com/sim0n00ps/OF-DL/issues/772

This PR addresses two problems: one relating to docker and one relating to auth.

## Docker problem

I added `user=root` to the supervisord config in 1.9.4 to address a warning that supervisord printed in the log (seen below). This change caused issues when users ran the docker container as a different user (using the `-u` docker run parameter). When the docker container user was manually changed, the programs managed by supervisord didn't run, and the OF-DL binary was not executed.

```
2025-04-01 20:24:18,122 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
```

## Auth problem

The code change to the AuthHelper adds some code to handle failure to open the browser more gracefully. I was able to cause an issue by exiting the OF-DL docker container while chromium (controlled by puppeteer) was running and waiting for the user to log in. Puppeteer would have issues in subsequent runs due to a lockfile specifying that the chromium profile was being controlled by another program (previous run of OF-DL). Instead of deleting the lockfile, I chose to remove the entire `chrome-data` directory and re-try launching the browser.