### PR TITLE
Dump config to log file when logging level is changed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,11 @@ RUN apk --no-cache --repository community add \
 # Redirect webroot to vnc.html instead of displaying directory listing
 RUN echo "<!DOCTYPE html><html><head><meta http-equiv=\"Refresh\" content=\"0; url='vnc.html'\" /></head><body></body></html>" > /usr/share/novnc/index.html
 
-# Copy release
-COPY --from=build /src/out /app
-
 # Create directories for configuration and downloaded files
 RUN mkdir /data /config /config/logs /default-config
+
+# Copy release
+COPY --from=build /src/out /app
 
 # Copy default configuration files
 COPY --from=build /src/config.conf /default-config

--- a/OF DL/Program.cs
+++ b/OF DL/Program.cs
@@ -2945,6 +2945,11 @@ public class Program
 
 						currentConfig = newConfig;
 
+                                                // Dump new config in the log file
+					        Log.Debug("Configuration:");
+					        string configString = JsonConvert.SerializeObject(currentConfig, Formatting.Indented);
+					        Log.Debug(configString);
+
                         var hoconConfig = new StringBuilder();
                         hoconConfig.AppendLine("# External Tools");
                         hoconConfig.AppendLine("External {");


### PR DESCRIPTION
Solves #687.

Also moved one of the Docker `RUN` commands up to take advantage of caching during `docker build` phase.