### PR TITLE
Add default VERSION ARG to avoid Docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.20 AS build
 
-ARG VERSION
+ARG VERSION=1.0.0
 
 RUN apk --no-cache --repository community add \
       dotnet8-sdk


### PR DESCRIPTION
This Pull Request fixes an issue in the Dockerfile that prevented it from building when the VERSION build argument was not explicitly provided.